### PR TITLE
Add tvOS support to CocoaPods podspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ This repository contains the [Adobe](https://www.adobe.com) integration for the 
 
 1. Add the kit dependency to your app's package management file:
 
-> To send media data to Adobe, you must use CocoaPods or SPM since their SDKs do not support Carthage
+> To send media data to Adobe, you must use CocoaPods or SPM since their SDKs do not support Carthage (iOS only)
 
 ```
 pod 'mParticle-Adobe/AdobeMedia', '~> 8.0'
 ```
 
-> Otherwise, for the previous non-media Adobe integration, you can integrate via Carthage or CocoaPods
+> Otherwise, for the previous non-media Adobe integration, you can integrate via Carthage or CocoaPods (iOS and tvOS)
 
 ```
 pod 'mParticle-Adobe/Adobe', '~> 8.0'

--- a/mParticle-Adobe.podspec
+++ b/mParticle-Adobe.podspec
@@ -16,8 +16,10 @@ Pod::Spec.new do |s|
     s.static_framework = true
     s.swift_version = "5.0"
 
-    s.ios.deployment_target = "10.0"
     s.default_subspec = 'AdobeMedia'
+
+    s.ios.deployment_target = "10.0"
+    s.tvos.deployment_target = "10.0"
 
     s.ios.pod_target_xcconfig = {
         'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'
@@ -26,14 +28,18 @@ Pod::Spec.new do |s|
         'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'
     }
 
-    s.subspec 'Adobe' do |ss|
-        ss.ios.source_files      = 'mParticle-Adobe/*.{h,m}'
-        ss.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
     s.ios.framework = 'UIKit'
+
+    s.subspec 'Adobe' do |ss|
+        ss.ios.source_files = 'mParticle-Adobe/*.{h,m}'
+        ss.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
+        
+        ss.tvos.source_files = 'mParticle-Adobe/*.{h,m}'
+        ss.tvos.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
     end
 
     s.subspec 'AdobeMedia' do |ss|
-        ss.ios.source_files      = 'mParticle-Adobe-Media/*.{h,m}'
+        ss.ios.source_files = 'mParticle-Adobe-Media/*.{h,m}'
         ss.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
         ss.ios.dependency 'mParticle-Apple-Media-SDK', '~> 1.3'
         ss.ios.dependency 'AEPMedia', '~> 3.0'
@@ -43,5 +49,9 @@ Pod::Spec.new do |s|
         ss.ios.dependency 'AEPIdentity', '~> 3.2'
         ss.ios.dependency 'AEPLifecycle', '~> 3.2'
         ss.ios.dependency 'AEPSignal', '~> 3.2'
+
+        # AdobeMedia is not supported on tvOS, so just pull in standard Adobe Kit code
+        ss.tvos.source_files = 'mParticle-Adobe/*.{h,m}'
+        ss.tvos.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
     end
 end


### PR DESCRIPTION
Added tvOS support for CocoaPods for the standard Adobe Kit (not media, as Adobe's frameworks don't support tvOS). Also updated the readme file to clarify which subspec works on tvOS.