### PR TITLE
Fix/fix spm imports

### DIFF
--- a/mParticle-Adobe-Media/MPKitAdobeMedia.m
+++ b/mParticle-Adobe-Media/MPKitAdobeMedia.m
@@ -1,13 +1,61 @@
 #import "MPKitAdobeMedia.h"
 #import "MPIAdobe.h"
+#if defined(__has_include) && __has_include(<AEPCore/AEPCore.h>)
+#import <AEPCore/AEPCore.h>
+#elseif defined(__has_include) && __has_include(AEPCore.h)
+#import "AEPCore.h"
+#else
 @import AEPCore;
+#endif
+#if defined(__has_include) && __has_include(<AEPAnalytics/AEPAnalytics.h>)
+#import <AEPAnalytics/AEPAnalytics.h>
+#elseif defined(__has_include) && __has_include(AEPAnalytics.h)
+#import "AEPAnalytics.h"
+#else
 @import AEPAnalytics;
+#endif
+#if defined(__has_include) && __has_include(<AEPMedia/AEPMedia.h>)
+#import <AEPMedia/AEPMedia.h>
+#elseif defined(__has_include) && __has_include(AEPMedia.h)
+#import "AEPMedia.h"
+#else
 @import AEPMedia;
+#endif
+#if defined(__has_include) && __has_include(<AEPUserProfile/AEPUserProfile.h>)
+#import <AEPUserProfile/AEPUserProfile.h>
+#elseif defined(__has_include) && __has_include(AEPUserProfile.h)
+#import "AEPUserProfile.h"
+#else
 @import AEPUserProfile;
+#endif
+#if defined(__has_include) && __has_include(<AEPIdentity/AEPIdentity.h>)
+#import <AEPIdentity/AEPIdentity.h>
+#elseif defined(__has_include) && __has_include(AEPIdentity.h)
+#import "AEPIdentity.h"
+#else
 @import AEPIdentity;
+#endif
+#if defined(__has_include) && __has_include(<AEPLifecycle/AEPLifecycle.h>)
+#import <AEPLifecycle/AEPLifecycle.h>
+#elseif defined(__has_include) && __has_include(AEPLifecycle.h)
+#import "AEPLifecycle.h"
+#else
 @import AEPLifecycle;
+#endif
+#if defined(__has_include) && __has_include(<AEPSignal/AEPSignal.h>)
+#import <AEPSignal/AEPSignal.h>
+#elseif defined(__has_include) && __has_include(AEPSignal.h)
+#import "AEPSignal.h"
+#else
 @import AEPSignal;
+#endif
+#if defined(__has_include) && __has_include(<AEPServices/AEPServices.h>)
+#import <AEPServices/AEPServices.h>
+#elseif defined(__has_include) && __has_include(AEPServices.h)
+#import "AEPServices.h"
+#else
 @import AEPServices;
+#endif
 
 @import mParticle_Apple_Media_SDK;
 @import mParticle_Apple_SDK;

--- a/mParticle-Adobe-Media/mParticle_Adobe_Media.h
+++ b/mParticle-Adobe-Media/mParticle_Adobe_Media.h
@@ -7,9 +7,8 @@ FOUNDATION_EXPORT double mParticle_Adobe_MediaVersionNumber;
 FOUNDATION_EXPORT const unsigned char mParticle_Adobe_MediaVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <mParticle_Adobe_Media/PublicHeader.h>
-#if defined(__has_include) && __has_include(<mParticle_Adobe/MPKitAdobeMedia.h>)
-#import <mParticle_Adobe/MPKitAdobeMedia.h>
-#else
+#if defined(__has_include) && __has_include(<mParticle_Adobe_Media/MPKitAdobeMedia.h>)
 #import <mParticle_Adobe_Media/MPKitAdobeMedia.h>
+#else
+#import "MPKitAdobeMedia.h"
 #endif
-

--- a/mParticle-Adobe/mParticle_Adobe.h
+++ b/mParticle-Adobe/mParticle_Adobe.h
@@ -8,4 +8,8 @@ FOUNDATION_EXPORT const unsigned char mParticle_AdobeVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <mParticle_Adobe/PublicHeader.h>
 
+#if defined(__has_include) && __has_include(<mParticle_Adobe/MPKitAdobe.h>)
 #import <mParticle_Adobe/MPKitAdobe.h>
+#else
+#import "MPKitAdobe.h"
+#endif


### PR DESCRIPTION
# Summary

While trying to import the package into one of their swift files a developer was getting the following error "Could not build objective-c module mParticle_Adobe". 

Tested through targeting this branch with SPM in in swift example app.
