### PR TITLE
feat: Improve marketing cloud ID override

### DIFF
--- a/mParticle-Adobe/MPKitAdobe.h
+++ b/mParticle-Adobe/MPKitAdobe.h
@@ -21,5 +21,6 @@
 @property (nonatomic, strong, nullable) MPKitAPI *kitApi;
 
 + (void)overrideMarketingCloudId:(NSString * _Nullable)mid;
++ (void)willOverrideMarketingCloudId:(BOOL)willOverrideMid;
 
 @end


### PR DESCRIPTION
## Summary
- Improve marketing cloud ID override

## Testing Plan
- Tested locally and confirmed that kit load order no longer matters when override is implemented correctly

## Reference Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4728
