### PR TITLE
fix: Header imports for mParticle SDK

### DIFF
--- a/mParticle-Adobe-Media/MPIAdobe.m
+++ b/mParticle-Adobe-Media/MPIAdobe.m
@@ -1,9 +1,14 @@
 // Be sure to apply changes to both copies of this file in the repository
 #import "MPIAdobe.h"
 #if defined(__has_include) && __has_include(<mParticle_Apple_SDK/mParticle.h>)
-#import <mParticle_Apple_SDK/mParticle.h>
+    #import <mParticle_Apple_SDK/mParticle.h>
+    #import <mParticle_Apple_SDK/mParticle_Apple_SDK-Swift.h>
+#elif defined(__has_include) && __has_include(<mParticle_Apple_SDK_NoLocation/mParticle.h>)
+    #import <mParticle_Apple_SDK_NoLocation/mParticle.h>
+    #import <mParticle_Apple_SDK_NoLocation/mParticle_Apple_SDK-Swift.h>
 #else
-#import "mParticle.h"
+    #import "mParticle.h"
+    #import "mParticle_Apple_SDK-Swift.h"
 #endif
 
 NSString *const MPIAdobeErrorKey = @"MPIAdobeErrorKey";

--- a/mParticle-Adobe-Media/MPKitAdobeMedia.h
+++ b/mParticle-Adobe-Media/MPKitAdobeMedia.h
@@ -1,8 +1,13 @@
 #import <Foundation/Foundation.h>
 #if defined(__has_include) && __has_include(<mParticle_Apple_SDK/mParticle.h>)
-#import <mParticle_Apple_SDK/mParticle.h>
+    #import <mParticle_Apple_SDK/mParticle.h>
+    #import <mParticle_Apple_SDK/mParticle_Apple_SDK-Swift.h>
+#elif defined(__has_include) && __has_include(<mParticle_Apple_SDK_NoLocation/mParticle.h>)
+    #import <mParticle_Apple_SDK_NoLocation/mParticle.h>
+    #import <mParticle_Apple_SDK_NoLocation/mParticle_Apple_SDK-Swift.h>
 #else
-#import "mParticle.h"
+    #import "mParticle.h"
+    #import "mParticle_Apple_SDK-Swift.h"
 #endif
 
 #pragma mark - MPIAdobeApi

--- a/mParticle-Adobe.podspec
+++ b/mParticle-Adobe.podspec
@@ -21,13 +21,6 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "10.0"
     s.tvos.deployment_target = "10.0"
 
-    s.ios.pod_target_xcconfig = {
-        'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'
-    }
-    s.ios.user_target_xcconfig = {
-        'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'
-    }
-
     s.ios.framework = 'UIKit'
 
     s.subspec 'Adobe' do |ss|

--- a/mParticle-Adobe/MPIAdobe.m
+++ b/mParticle-Adobe/MPIAdobe.m
@@ -1,9 +1,14 @@
 // Be sure to apply changes to both copies of this file in the repository
 #import "MPIAdobe.h"
 #if defined(__has_include) && __has_include(<mParticle_Apple_SDK/mParticle.h>)
-#import <mParticle_Apple_SDK/mParticle.h>
+    #import <mParticle_Apple_SDK/mParticle.h>
+    #import <mParticle_Apple_SDK/mParticle_Apple_SDK-Swift.h>
+#elif defined(__has_include) && __has_include(<mParticle_Apple_SDK_NoLocation/mParticle.h>)
+    #import <mParticle_Apple_SDK_NoLocation/mParticle.h>
+    #import <mParticle_Apple_SDK_NoLocation/mParticle_Apple_SDK-Swift.h>
 #else
-#import "mParticle.h"
+    #import "mParticle.h"
+    #import "mParticle_Apple_SDK-Swift.h"
 #endif
 
 NSString *const MPIAdobeErrorKey = @"MPIAdobeErrorKey";

--- a/mParticle-Adobe/MPKitAdobe.h
+++ b/mParticle-Adobe/MPKitAdobe.h
@@ -1,8 +1,13 @@
 #import <Foundation/Foundation.h>
 #if defined(__has_include) && __has_include(<mParticle_Apple_SDK/mParticle.h>)
-#import <mParticle_Apple_SDK/mParticle.h>
+    #import <mParticle_Apple_SDK/mParticle.h>
+    #import <mParticle_Apple_SDK/mParticle_Apple_SDK-Swift.h>
+#elif defined(__has_include) && __has_include(<mParticle_Apple_SDK_NoLocation/mParticle.h>)
+    #import <mParticle_Apple_SDK_NoLocation/mParticle.h>
+    #import <mParticle_Apple_SDK_NoLocation/mParticle_Apple_SDK-Swift.h>
 #else
-#import "mParticle.h"
+    #import "mParticle.h"
+    #import "mParticle_Apple_SDK-Swift.h"
 #endif
 
 #pragma mark - MPIAdobeApi


### PR DESCRIPTION
## Summary
Adds headers for accessing public Swift classes in the core SDK. Marked as fix so semantic release will make a patch version bump instead of minor version bump.

## Testing Instructions
Tested by compiling and running a local app to see that there were no header or Swift related errors.