### PR TITLE
feat: Add Privacy Manifest for iOS 17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ playground.xcworkspace
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 # Packages/
 .build/
+Package.resolved
 
 # CocoaPods
 #

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "mparticle/mparticle-apple-sdk" ~> 8.0
+binary "https://raw.githubusercontent.com/mParticle/mparticle-apple-sdk/main/mParticle_Apple_SDK.json" ~> 8.22

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "mParticle-Adobe",
-    platforms: [.iOS(.v10)],
+    platforms: [.iOS(.v12)],
     products: [
         .library(name: "mParticle-Adobe", targets: ["mParticle-Adobe"]),
         .library(name: "mParticle-Adobe-Media", targets: ["mParticle-Adobe-Media"])
@@ -21,16 +21,16 @@ let package = Package(
         .package(
             name: "AEPCore",
             url: "https://github.com/adobe/aepsdk-core-ios.git",
-            .upToNextMajor(from: "3.2.0")),
+            .upToNextMajor(from: "5.0.0")),
         .package(name: "AEPUserProfile",
             url: "https://github.com/adobe/aepsdk-userprofile-ios.git",
-            .upToNextMajor(from: "3.0.0")),
+            .upToNextMajor(from: "5.0.0")),
         .package(name: "AEPAnalytics",
             url: "https://github.com/adobe/aepsdk-analytics-ios.git",
-            .upToNextMajor(from: "3.0.0")),
+            .upToNextMajor(from: "5.0.0")),
         .package(name: "AEPMedia",
             url: "https://github.com/adobe/aepsdk-media-ios.git",
-            .upToNextMajor(from: "3.0.0"))
+            .upToNextMajor(from: "5.0.0"))
 
     ],
     targets: [
@@ -38,6 +38,8 @@ let package = Package(
             name: "mParticle-Adobe",
             dependencies: ["mParticle-Apple-SDK"],
             path: "mParticle-Adobe",
+            exclude: ["Dummy.swift", "Info.plist"],
+            resources: [.process("PrivacyInfo.xcprivacy")],
             publicHeadersPath: "."),
         .target(
             name: "mParticle-Adobe-Media",
@@ -53,7 +55,8 @@ let package = Package(
                 .product(name: "AEPSignal", package: "AEPCore"),
             ],
             path: "mParticle-Adobe-Media",
-            exclude: ["Dummy.swift"],
+            exclude: ["Dummy.swift", "Info.plist"],
+            resources: [.process("PrivacyInfo.xcprivacy")],
             publicHeadersPath: "."),
     ]
 )

--- a/Podfile
+++ b/Podfile
@@ -1,17 +1,20 @@
 # Uncomment the next line to define a global platform for your project
-platform :ios, '11.0'
+platform :ios, '12.0'
 
 project 'mParticle-Adobe-Media.xcodeproj'
 
 target 'mParticle-Adobe-Media' do
-  # Comment the next line if you don't want to use dynamic frameworks
-  use_frameworks!
+    # Comment the next line if you don't want to use dynamic frameworks
+    use_frameworks!
 
-  pod 'mParticle-Apple-Media-SDK', '~> 1.3.1'
-  pod 'mParticle-Apple-SDK', '~> 8.0-beta'
-  pod 'ACPMedia', '~> 1.0'
-  pod 'ACPAnalytics', '~> 2.0'
-  pod 'ACPCore', '~> 2.0'
-  pod 'ACPUserProfile', '~> 2.0'
+    pod 'mParticle-Apple-Media-SDK', '~> 1.5'
+    pod 'mParticle-Apple-SDK', '~> 8.22'
+    pod 'AEPMedia', '~> 5.0'
+    pod 'AEPAnalytics', '~> 5.0'
+    pod 'AEPCore', '~> 5.0'
+    pod 'AEPUserProfile', '~> 5.0'
+    pod 'AEPIdentity', '~> 5.0'
+    pod 'AEPLifecycle', '~> 5.0'
+    pod 'AEPSignal', '~> 5.0'
 
 end

--- a/mParticle-Adobe-Media.xcodeproj/project.pbxproj
+++ b/mParticle-Adobe-Media.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2F60DECCEA7A3FED2127E486 /* Pods_mParticle_Adobe_Media.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3BD6F6EA14B7F098A5570C8B /* Pods_mParticle_Adobe_Media.framework */; };
+		539D972C2BF3D95200ADD3B6 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 539D972B2BF3D95200ADD3B6 /* PrivacyInfo.xcprivacy */; };
 		D30B695F2333DE1A002FE9F2 /* MPIAdobe.h in Headers */ = {isa = PBXBuildFile; fileRef = D30B695D2333DE1A002FE9F2 /* MPIAdobe.h */; };
 		D30B69602333DE1A002FE9F2 /* MPIAdobe.m in Sources */ = {isa = PBXBuildFile; fileRef = D30B695E2333DE1A002FE9F2 /* MPIAdobe.m */; };
 		D31BBD9E2327FF0B008C510B /* mParticle_Adobe_Media.h in Headers */ = {isa = PBXBuildFile; fileRef = D31BBD9C2327FF0B008C510B /* mParticle_Adobe_Media.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -18,6 +19,7 @@
 
 /* Begin PBXFileReference section */
 		3BD6F6EA14B7F098A5570C8B /* Pods_mParticle_Adobe_Media.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_mParticle_Adobe_Media.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		539D972B2BF3D95200ADD3B6 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		8F7D178A9527F1BDA3990282 /* Pods-mParticle-Adobe-Media.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-mParticle-Adobe-Media.release.xcconfig"; path = "Target Support Files/Pods-mParticle-Adobe-Media/Pods-mParticle-Adobe-Media.release.xcconfig"; sourceTree = "<group>"; };
 		D30B695D2333DE1A002FE9F2 /* MPIAdobe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MPIAdobe.h; sourceTree = "<group>"; };
 		D30B695E2333DE1A002FE9F2 /* MPIAdobe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MPIAdobe.m; sourceTree = "<group>"; };
@@ -78,6 +80,7 @@
 				D31BBD9C2327FF0B008C510B /* mParticle_Adobe_Media.h */,
 				D31BBD9D2327FF0B008C510B /* Info.plist */,
 				D31BBDA8232818BD008C510B /* Dummy.swift */,
+				539D972B2BF3D95200ADD3B6 /* PrivacyInfo.xcprivacy */,
 			);
 			path = "mParticle-Adobe-Media";
 			sourceTree = "<group>";
@@ -164,6 +167,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				539D972C2BF3D95200ADD3B6 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -259,7 +263,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -314,7 +318,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;

--- a/mParticle-Adobe-Media/MPKitAdobeMedia.m
+++ b/mParticle-Adobe-Media/MPKitAdobeMedia.m
@@ -2,63 +2,62 @@
 #import "MPIAdobe.h"
 #if defined(__has_include) && __has_include(<AEPCore/AEPCore.h>)
 #import <AEPCore/AEPCore.h>
-#elseif defined(__has_include) && __has_include(AEPCore.h)
+#elif defined(__has_include) && __has_include("AEPCore.h")
 #import "AEPCore.h"
 #else
 @import AEPCore;
 #endif
 #if defined(__has_include) && __has_include(<AEPAnalytics/AEPAnalytics.h>)
 #import <AEPAnalytics/AEPAnalytics.h>
-#elseif defined(__has_include) && __has_include(AEPAnalytics.h)
+#elif defined(__has_include) && __has_include("AEPAnalytics.h")
 #import "AEPAnalytics.h"
 #else
 @import AEPAnalytics;
 #endif
 #if defined(__has_include) && __has_include(<AEPMedia/AEPMedia.h>)
 #import <AEPMedia/AEPMedia.h>
-#elseif defined(__has_include) && __has_include(AEPMedia.h)
+#elif defined(__has_include) && __has_include("AEPMedia.h")
 #import "AEPMedia.h"
 #else
 @import AEPMedia;
 #endif
 #if defined(__has_include) && __has_include(<AEPUserProfile/AEPUserProfile.h>)
 #import <AEPUserProfile/AEPUserProfile.h>
-#elseif defined(__has_include) && __has_include(AEPUserProfile.h)
+#elif defined(__has_include) && __has_include("AEPUserProfile.h")
 #import "AEPUserProfile.h"
 #else
 @import AEPUserProfile;
 #endif
 #if defined(__has_include) && __has_include(<AEPIdentity/AEPIdentity.h>)
 #import <AEPIdentity/AEPIdentity.h>
-#elseif defined(__has_include) && __has_include(AEPIdentity.h)
+#elif defined(__has_include) && __has_include("AEPIdentity.h")
 #import "AEPIdentity.h"
 #else
 @import AEPIdentity;
 #endif
 #if defined(__has_include) && __has_include(<AEPLifecycle/AEPLifecycle.h>)
 #import <AEPLifecycle/AEPLifecycle.h>
-#elseif defined(__has_include) && __has_include(AEPLifecycle.h)
+#elif defined(__has_include) && __has_include("AEPLifecycle.h")
 #import "AEPLifecycle.h"
 #else
 @import AEPLifecycle;
 #endif
 #if defined(__has_include) && __has_include(<AEPSignal/AEPSignal.h>)
 #import <AEPSignal/AEPSignal.h>
-#elseif defined(__has_include) && __has_include(AEPSignal.h)
+#elif defined(__has_include) && __has_include("AEPSignal.h")
 #import "AEPSignal.h"
 #else
 @import AEPSignal;
 #endif
 #if defined(__has_include) && __has_include(<AEPServices/AEPServices.h>)
 #import <AEPServices/AEPServices.h>
-#elseif defined(__has_include) && __has_include(AEPServices.h)
+#elif defined(__has_include) && __has_include("AEPServices.h")
 #import "AEPServices.h"
 #else
 @import AEPServices;
 #endif
 
 @import mParticle_Apple_Media_SDK;
-@import mParticle_Apple_SDK;
 
 static NSString *const marketingCloudIdIntegrationAttributeKey = @"mid";
 static NSString *const blobIntegrationAttributeKey = @"aamb";

--- a/mParticle-Adobe-Media/PrivacyInfo.xcprivacy
+++ b/mParticle-Adobe-Media/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array/>
+</dict>
+</plist>

--- a/mParticle-Adobe.podspec
+++ b/mParticle-Adobe.podspec
@@ -18,33 +18,35 @@ Pod::Spec.new do |s|
 
     s.default_subspec = 'AdobeMedia'
 
-    s.ios.deployment_target = "10.0"
-    s.tvos.deployment_target = "10.0"
-
-    s.ios.framework = 'UIKit'
+    s.ios.deployment_target = "12.0"
+    s.tvos.deployment_target = "12.0"
 
     s.subspec 'Adobe' do |ss|
         ss.ios.source_files = 'mParticle-Adobe/*.{h,m}'
-        ss.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
+        ss.ios.resource_bundles  = { 'mParticle-Adobe-Privacy' => ['mParticle-Adobe/PrivacyInfo.xcprivacy'] }
+        ss.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.22'
         
         ss.tvos.source_files = 'mParticle-Adobe/*.{h,m}'
-        ss.tvos.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
+        ss.tvos.resource_bundles  = { 'mParticle-Adobe-Privacy' => ['mParticle-Adobe/PrivacyInfo.xcprivacy'] }
+        ss.tvos.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.22'
     end
 
     s.subspec 'AdobeMedia' do |ss|
         ss.ios.source_files = 'mParticle-Adobe-Media/*.{h,m}'
-        ss.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
-        ss.ios.dependency 'mParticle-Apple-Media-SDK', '~> 1.3'
-        ss.ios.dependency 'AEPMedia', '~> 3.0'
-        ss.ios.dependency 'AEPAnalytics', '~> 3.0'
-        ss.ios.dependency 'AEPCore', '~> 3.2'
-        ss.ios.dependency 'AEPUserProfile', '~> 3.0'
-        ss.ios.dependency 'AEPIdentity', '~> 3.2'
-        ss.ios.dependency 'AEPLifecycle', '~> 3.2'
-        ss.ios.dependency 'AEPSignal', '~> 3.2'
+        ss.ios.resource_bundles  = { 'mParticle-Adobe-Media-Privacy' => ['mParticle-Adobe-Media/PrivacyInfo.xcprivacy'] }
+        ss.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.22'
+        ss.ios.dependency 'mParticle-Apple-Media-SDK', '~> 1.5'
+        ss.ios.dependency 'AEPMedia', '~> 5.0'
+        ss.ios.dependency 'AEPAnalytics', '~> 5.0'
+        ss.ios.dependency 'AEPCore', '~> 5.0'
+        ss.ios.dependency 'AEPUserProfile', '~> 5.0'
+        ss.ios.dependency 'AEPIdentity', '~> 5.0'
+        ss.ios.dependency 'AEPLifecycle', '~> 5.0'
+        ss.ios.dependency 'AEPSignal', '~> 5.0'
 
         # AdobeMedia is not supported on tvOS, so just pull in standard Adobe Kit code
         ss.tvos.source_files = 'mParticle-Adobe/*.{h,m}'
-        ss.tvos.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
+        ss.tvos.resource_bundles  = { 'mParticle-Adobe-Privacy' => ['mParticle-Adobe/PrivacyInfo.xcprivacy'] }
+        ss.tvos.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.22'
     end
 end

--- a/mParticle-Adobe.xcodeproj/project.pbxproj
+++ b/mParticle-Adobe.xcodeproj/project.pbxproj
@@ -3,25 +3,27 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		539D972E2BF3D98100ADD3B6 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 539D972D2BF3D98100ADD3B6 /* PrivacyInfo.xcprivacy */; };
+		539D97302BF3D99000ADD3B6 /* mParticle_Apple_SDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 539D972F2BF3D99000ADD3B6 /* mParticle_Apple_SDK.xcframework */; };
 		DB0773DB1DB916610031F3E3 /* mParticle_Adobe.h in Headers */ = {isa = PBXBuildFile; fileRef = DB0773D91DB916610031F3E3 /* mParticle_Adobe.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB0773E31DB916B80031F3E3 /* MPKitAdobe.h in Headers */ = {isa = PBXBuildFile; fileRef = DB0773E11DB916B80031F3E3 /* MPKitAdobe.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB0773E41DB916B80031F3E3 /* MPKitAdobe.m in Sources */ = {isa = PBXBuildFile; fileRef = DB0773E21DB916B80031F3E3 /* MPKitAdobe.m */; };
-		DB0773E61DB917DB0031F3E3 /* mParticle_Apple_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB0773E51DB917DB0031F3E3 /* mParticle_Apple_SDK.framework */; };
 		DB6F8E051F337B2500328DC2 /* MPIAdobe.h in Headers */ = {isa = PBXBuildFile; fileRef = DB6F8E031F337B2500328DC2 /* MPIAdobe.h */; };
 		DB6F8E061F337B2500328DC2 /* MPIAdobe.m in Sources */ = {isa = PBXBuildFile; fileRef = DB6F8E041F337B2500328DC2 /* MPIAdobe.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		539D972D2BF3D98100ADD3B6 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		539D972F2BF3D99000ADD3B6 /* mParticle_Apple_SDK.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:DLD43Y3TRP:mParticle, inc"; lastKnownFileType = wrapper.xcframework; name = mParticle_Apple_SDK.xcframework; path = Carthage/Build/mParticle_Apple_SDK.xcframework; sourceTree = "<group>"; };
 		DB0773D61DB916610031F3E3 /* mParticle_Adobe.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = mParticle_Adobe.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DB0773D91DB916610031F3E3 /* mParticle_Adobe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = mParticle_Adobe.h; sourceTree = "<group>"; };
 		DB0773DA1DB916610031F3E3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DB0773E11DB916B80031F3E3 /* MPKitAdobe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPKitAdobe.h; sourceTree = "<group>"; };
 		DB0773E21DB916B80031F3E3 /* MPKitAdobe.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPKitAdobe.m; sourceTree = "<group>"; };
-		DB0773E51DB917DB0031F3E3 /* mParticle_Apple_SDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = mParticle_Apple_SDK.framework; path = Carthage/Build/iOS/mParticle_Apple_SDK.framework; sourceTree = "<group>"; };
 		DB6F8E031F337B2500328DC2 /* MPIAdobe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MPIAdobe.h; sourceTree = "<group>"; };
 		DB6F8E041F337B2500328DC2 /* MPIAdobe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MPIAdobe.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -31,7 +33,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DB0773E61DB917DB0031F3E3 /* mParticle_Apple_SDK.framework in Frameworks */,
+				539D97302BF3D99000ADD3B6 /* mParticle_Apple_SDK.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -41,7 +43,7 @@
 		DB0773CC1DB916610031F3E3 = {
 			isa = PBXGroup;
 			children = (
-				DB0773E51DB917DB0031F3E3 /* mParticle_Apple_SDK.framework */,
+				539D972F2BF3D99000ADD3B6 /* mParticle_Apple_SDK.xcframework */,
 				DB0773D81DB916610031F3E3 /* mParticle-Adobe */,
 				DB0773D71DB916610031F3E3 /* Products */,
 			);
@@ -64,6 +66,7 @@
 				DB6F8E041F337B2500328DC2 /* MPIAdobe.m */,
 				DB0773D91DB916610031F3E3 /* mParticle_Adobe.h */,
 				DB0773DA1DB916610031F3E3 /* Info.plist */,
+				539D972D2BF3D98100ADD3B6 /* PrivacyInfo.xcprivacy */,
 			);
 			path = "mParticle-Adobe";
 			sourceTree = "<group>";
@@ -140,6 +143,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				539D972E2BF3D98100ADD3B6 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -199,7 +203,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -244,7 +248,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -270,8 +274,11 @@
 				);
 				INFOPLIST_FILE = "mParticle-Adobe/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Adobe";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -294,8 +301,11 @@
 				);
 				INFOPLIST_FILE = "mParticle-Adobe/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Adobe";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/mParticle-Adobe/PrivacyInfo.xcprivacy
+++ b/mParticle-Adobe/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array/>
+</dict>
+</plist>


### PR DESCRIPTION
 ## Summary
 - Add privacy manifest to kit
 - Update Adobe Media SDKs to latest 5.0.0 version to get their privacy manifests
 - Fixed some header import issues I discovered
 - Raised deployment target to iOS 12 to match Adobe

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - E2E tested with both Cocoapods and SPM test app up to Adobe Cloud and confirmed receipt of events.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6464
