### PR TITLE
fix: Prevent Integration Attribute Override with NSNull values

### DIFF
--- a/mParticle-Adobe/MPIAdobe.m
+++ b/mParticle-Adobe/MPIAdobe.m
@@ -36,8 +36,6 @@ static NSString *const idSuffix = @"%01";
 
 static NSString *const errorResponseKey = @"error_msg";
 
-static NSString *const invalidMarketingCloudId = @"<null>";
-
 static NSString *const errorDomain = @"mParticle-Adobe";
 static NSString *const serverErrorDomain = @"mParticle-Adobe Server Response";
 

--- a/mParticle-Adobe/MPIAdobe.m
+++ b/mParticle-Adobe/MPIAdobe.m
@@ -172,13 +172,9 @@ static NSString *const marketingCloudIdUserDefaultsKey = @"ADBMOBILE_PERSISTED_M
             return callbackWithCode(MPIAdobeErrorCodeServerError, @"Server returned an error", error);
         }
         
-        NSString *marketingCloudId = dictionary[marketingCloudIdKey];
-        if ([marketingCloudId isEqualToString:invalidMarketingCloudId]) {
-            marketingCloudId = nil;
-        }
-        
-        NSString *region = [NSString stringWithFormat:@"%@", dictionary[regionKey]];
-        NSString *blob = dictionary[blobKey];
+        NSString *marketingCloudId = [dictionary[marketingCloudIdKey] isKindOfClass:[NSString class]] ? dictionary[marketingCloudIdKey] : nil;
+        NSString *region = [dictionary[regionKey] isKindOfClass:[NSString class]] ? dictionary[regionKey] : nil;
+        NSString *blob = [dictionary[blobKey] isKindOfClass:[NSString class]] ? dictionary[blobKey] : nil;
         
         weakSelf.region = region;
         weakSelf.blob = blob;


### PR DESCRIPTION
## Summary
 - Prevents NSNull values from reading as nonnill and overwriting the existing  integrationAttributes.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested logic locally in a sample app

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7653
