### PR TITLE
fix: SDKE-360 create defensive copies of strings for completion callback parameters

### DIFF
--- a/mParticle-Adobe/MPIAdobe.m
+++ b/mParticle-Adobe/MPIAdobe.m
@@ -177,7 +177,7 @@ static NSString *const marketingCloudIdUserDefaultsKey = @"ADBMOBILE_PERSISTED_M
         weakSelf.region = region;
         weakSelf.blob = blob;
         
-        completion(marketingCloudId, region, blob, nil);
+        completion([marketingCloudId copy], [region copy], [blob copy], nil);
     }] resume];
 }
 

--- a/mParticle-Adobe/MPIAdobe.m
+++ b/mParticle-Adobe/MPIAdobe.m
@@ -79,7 +79,7 @@ static NSString *const marketingCloudIdUserDefaultsKey = @"ADBMOBILE_PERSISTED_M
 
 @implementation MPIAdobe
 
-- (void)sendRequestWithMarketingCloudId:(NSString *)marketingCloudId advertiserId:(NSString *)advertiserId pushToken:(NSString *)pushToken organizationId:(NSString *)organizationId userIdentities:(NSDictionary<NSNumber *, NSString *> *)userIdentities audienceManagerServer:(NSString *)audienceManagerServer completion:(void (^)(NSString *marketingCloudId, NSString *blob, NSString *locationHint, NSError *))completion {
+- (void)sendRequestWithMarketingCloudId:(NSString *)marketingCloudId advertiserId:(NSString *)advertiserId pushToken:(NSString *)pushToken organizationId:(NSString *)organizationId userIdentities:(NSDictionary<NSNumber *, NSString *> *)userIdentities audienceManagerServer:(NSString *)audienceManagerServer completion:(void (^)(NSString *marketingCloudId, NSString *locationHint, NSString *blob, NSError *))completion {
     
     if (audienceManagerServer != nil && audienceManagerServer.length > 0) {
         host = audienceManagerServer;


### PR DESCRIPTION
 ## Summary
 - copy attributes to prevent potential releasing them from the memory
 - fix parameter order in definition

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://rokt.atlassian.net/browse/SDKE-360
