### PR TITLE
fix: sync AdobeMedia MID after AEP registration

### DIFF
--- a/mParticle-Adobe-Media/MPKitAdobeMedia.m
+++ b/mParticle-Adobe-Media/MPKitAdobeMedia.m
@@ -143,14 +143,13 @@ static NSString *const audienceManagerServerConfigurationKey = @"audienceManager
                 self.defaultMediaTracker = [AEPMobileMedia createTrackerWithConfig:config];
                 self.mediaTrackers = [[NSMutableDictionary<NSString *, id<AEPMediaTracker>> alloc] init];
                 NSLog(@"mParticle -> Adobe Media configured");
+                [self syncId];
             }];
         } else {
             NSLog(@"mParticle -> Adobe Media not configured");
         }
 
         self->_started = YES;
-        
-        [self syncId];
 
         dispatch_async(dispatch_get_main_queue(), ^{
             NSDictionary *userInfo = @{mParticleKitInstanceKey:[[self class] kitCode]};

--- a/mParticle-Adobe-Media/MPKitAdobeMedia.m
+++ b/mParticle-Adobe-Media/MPKitAdobeMedia.m
@@ -143,6 +143,7 @@ static NSString *const audienceManagerServerConfigurationKey = @"audienceManager
                 self.defaultMediaTracker = [AEPMobileMedia createTrackerWithConfig:config];
                 self.mediaTrackers = [[NSMutableDictionary<NSString *, id<AEPMediaTracker>> alloc] init];
                 NSLog(@"mParticle -> Adobe Media configured");
+                self.syncingId = NO;
                 [self syncId];
             }];
         } else {


### PR DESCRIPTION
## Background
AdobeMedia could request ECID before AEP extension registration completed, causing MID lookup to fail during startup. This change makes MID sync run only after AEP registration is complete.

## What Has Changed
- Moved the initial `syncId` call into the `registerExtensions` completion block
- Ensured the first ECID lookup happens after AEP extensions are initialized
- Removed the early startup `syncId` call that could trigger the race condition

## Screenshots/Video
N/A

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes
- This is a minimal, targeted fix in AdobeMedia startup ordering.

Made with [Cursor](https://cursor.com)