### PR TITLE
fix: Add explicit Adobe MID resolution logging

### DIFF
--- a/mParticle-Adobe-Media/MPKitAdobeMedia.m
+++ b/mParticle-Adobe-Media/MPKitAdobeMedia.m
@@ -399,6 +399,7 @@ static NSString *const audienceManagerServerConfigurationKey = @"audienceManager
                 BOOL didUpdateIntegrationAttributes = ![mid isEqualToString:existingMid];
                 if (didUpdateIntegrationAttributes) {
                     [[MParticle sharedInstance] setIntegrationAttributes:@{marketingCloudIdIntegrationAttributeKey: mid} forKit:[[self class] kitCode]];
+                    NSLog(@"mParticle -> Adobe Media - Updated integration attributes with Adobe cloud experience Id (marketing cloud Id)");
                 }
                 NSLog(@"mParticle -> Adobe Media - Successfully retrieved Adobe cloud experience Id (marketing cloud Id)%@", didUpdateIntegrationAttributes ? @"; updated integration attributes" : @"; integration attributes already up to date");
             } else {

--- a/mParticle-Adobe-Media/MPKitAdobeMedia.m
+++ b/mParticle-Adobe-Media/MPKitAdobeMedia.m
@@ -395,8 +395,14 @@ static NSString *const audienceManagerServerConfigurationKey = @"audienceManager
             NSLog(@"mParticle -> Adobe Media - Error getting Adobe cloud experience Id (marketing cloud Id): %@", error);
         } else {
             NSString *existingMid = [self marketingCloudIdFromIntegrationAttributes];
-            if (mid.length > 0 && ![mid isEqualToString:existingMid]) {
-                [[MParticle sharedInstance] setIntegrationAttributes:@{marketingCloudIdIntegrationAttributeKey: mid} forKit:[[self class] kitCode]];
+            if (mid.length > 0) {
+                BOOL didUpdateIntegrationAttributes = ![mid isEqualToString:existingMid];
+                if (didUpdateIntegrationAttributes) {
+                    [[MParticle sharedInstance] setIntegrationAttributes:@{marketingCloudIdIntegrationAttributeKey: mid} forKit:[[self class] kitCode]];
+                }
+                NSLog(@"mParticle -> Adobe Media - Successfully retrieved Adobe cloud experience Id (marketing cloud Id)%@", didUpdateIntegrationAttributes ? @"; updated integration attributes" : @"; integration attributes already up to date");
+            } else {
+                NSLog(@"mParticle -> Adobe Media - Adobe cloud experience Id (marketing cloud Id) was empty");
             }
         }
         self.syncingId = NO;


### PR DESCRIPTION
## Background
Troubleshooting MID resolution in runtime logs is currently ambiguous because only error output is explicit.
This change adds clear success-state logging for Adobe Media MID retrieval and persistence.

## What Has Changed
- Added explicit success log when Adobe MID is retrieved successfully
- Added explicit log when MID is empty (no error, but no value)
- Added explicit log when integration attributes are updated with MID
- Kept existing error logging intact for timeout/failure scenarios

## Screenshots/Video
N/A

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes
This update is diagnostic-only and does not change SDK behavior.