### PR TITLE
fix: defer AdobeMedia one-time init until launchAppId is available

### DIFF
--- a/mParticle-Adobe-Media/MPKitAdobeMedia.m
+++ b/mParticle-Adobe-Media/MPKitAdobeMedia.m
@@ -133,22 +133,22 @@ static NSString *const audienceManagerServerConfigurationKey = @"audienceManager
     static dispatch_once_t kitPredicate;
 
     NSString *launchAppId  = _configuration[launchAppIdKey];
+    if (launchAppId == nil) {
+        NSLog(@"mParticle -> Adobe Media config wasn't received yet.");
+        return;
+    }
     
     dispatch_once(&kitPredicate, ^{
         [AEPMobileCore setLogLevel:AEPLogLevelDebug];
-        if (launchAppId != nil) {
-            [AEPMobileCore registerExtensions:@[AEPMobileAnalytics.class, AEPMobileMedia.class, AEPMobileUserProfile.class, AEPMobileSignal.class, AEPMobileLifecycle.class, AEPMobileIdentity.class] completion:^{
-                [AEPMobileCore configureWithAppId:launchAppId];
-                NSMutableDictionary* config = [NSMutableDictionary dictionary];
-                self.defaultMediaTracker = [AEPMobileMedia createTrackerWithConfig:config];
-                self.mediaTrackers = [[NSMutableDictionary<NSString *, id<AEPMediaTracker>> alloc] init];
-                NSLog(@"mParticle -> Adobe Media configured");
-                self.syncingId = NO;
-                [self syncId];
-            }];
-        } else {
-            NSLog(@"mParticle -> Adobe Media not configured");
-        }
+        [AEPMobileCore registerExtensions:@[AEPMobileAnalytics.class, AEPMobileMedia.class, AEPMobileUserProfile.class, AEPMobileSignal.class, AEPMobileLifecycle.class, AEPMobileIdentity.class] completion:^{
+            [AEPMobileCore configureWithAppId:launchAppId];
+            NSMutableDictionary* config = [NSMutableDictionary dictionary];
+            self.defaultMediaTracker = [AEPMobileMedia createTrackerWithConfig:config];
+            self.mediaTrackers = [[NSMutableDictionary<NSString *, id<AEPMediaTracker>> alloc] init];
+            NSLog(@"mParticle -> Adobe Media configured");
+            self.syncingId = NO;
+            [self syncId];
+        }];
 
         self->_started = YES;
 


### PR DESCRIPTION
## Background
AdobeMedia startup could consume its one-time initialization path before `launchAppId` was available, preventing later initialization in the same process. This update ensures initialization is attempted only when configuration is present.

## What Has Changed
- Added an early `launchAppId` guard before entering the one-time initialization block
- Prevented `dispatch_once` from executing in unconfigured startup states
- Kept AdobeMedia initialization flow unchanged once configuration is available

## Screenshots/Video
N/A

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes
- This is a targeted initialization-order fix in `MPKitAdobeMedia.start`.